### PR TITLE
acct-(group|user)/ntp: add NTP group and user

### DIFF
--- a/acct-group/ntp/metadata.xml
+++ b/acct-group/ntp/metadata.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+  <maintainer type="project">
+    <email>base-system@gentoo.org</email>
+    <name>Gentoo Base System</name>
+  </maintainer>
+</pkgmetadata>

--- a/acct-group/ntp/ntp-0.ebuild
+++ b/acct-group/ntp/ntp-0.ebuild
@@ -1,0 +1,8 @@
+# Copyright 2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit acct-group
+
+ACCT_GROUP_ID=123

--- a/acct-user/ntp/metadata.xml
+++ b/acct-user/ntp/metadata.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+  <maintainer type="project">
+    <email>base-system@gentoo.org</email>
+    <name>Gentoo Base System</name>
+  </maintainer>
+</pkgmetadata>

--- a/acct-user/ntp/ntp-0.ebuild
+++ b/acct-user/ntp/ntp-0.ebuild
@@ -1,0 +1,12 @@
+# Copyright 2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit acct-user
+
+DESCRIPTION="user for ntp daemon"
+ACCT_USER_ID=123
+ACCT_USER_GROUPS=( ntp )
+
+acct-user_add_deps


### PR DESCRIPTION
Add NTP group and user; required for updating NTP to gentoo upstream ntp-4.2.8_p15.

# How to use / testing done
```
emerge-amd64-usr ntp
```