### PR TITLE
.github: use create-pull-request@v3 to fix set-env issues

### DIFF
--- a/.github/workflows/rust-pull-request-main.yml
+++ b/.github/workflows/rust-pull-request-main.yml
@@ -24,7 +24,7 @@ jobs:
           VERSION_NEW: ${{ steps.fetch-latest-release.outputs.VERSION_MAIN }}
         run: .github/workflows/rust-apply-patch.sh
       - name: Create pull request for main
-        uses: peter-evans/create-pull-request@v2
+        uses: peter-evans/create-pull-request@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           base: ${{ steps.fetch-latest-release.outputs.BASE_BRANCH_MAIN }}


### PR DESCRIPTION
Github Actions for Rust started failing with following errors:

```
Error: Unable to process command '::set-env name=PULL_REQUEST_NUMBER::718' successfully.
Error: The `set-env` command is disabled. Please upgrade to using
Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`.
For more information see:
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
```

It happens because we have used `peter-evans/create-pull-request@v2`, which did not have a bug fix for the set-env issue.
The bug was fixed in create-pull-request [v3.4.1](https://github.com/peter-evans/create-pull-request/releases/tag/v3.4.1).
So we just need to update the version to `v3`, which already includes v3.4.1.
