### PR TITLE
*: Drop the use of mirror://kernel

### DIFF
--- a/app-misc/zisofs-tools/zisofs-tools-1.0.6.ebuild
+++ b/app-misc/zisofs-tools/zisofs-tools-1.0.6.ebuild
@@ -6,7 +6,7 @@ inherit flag-o-matic
 
 DESCRIPTION="User utilities for zisofs"
 HOMEPAGE="http://www.kernel.org/pub/linux/utils/fs/zisofs/"
-SRC_URI="mirror://kernel/linux/utils/fs/zisofs/${P}.tar.bz2"
+SRC_URI="https://www.kernel.org/pub/linux/utils/fs/zisofs/${P}.tar.bz2"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/app-misc/zisofs-tools/zisofs-tools-1.0.8.ebuild
+++ b/app-misc/zisofs-tools/zisofs-tools-1.0.8.ebuild
@@ -6,7 +6,7 @@ inherit flag-o-matic
 
 DESCRIPTION="User utilities for zisofs"
 HOMEPAGE="http://www.kernel.org/pub/linux/utils/fs/zisofs/"
-SRC_URI="mirror://kernel/linux/utils/fs/zisofs/${P}.tar.bz2"
+SRC_URI="https://www.kernel.org/pub/linux/utils/fs/zisofs/${P}.tar.bz2"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/dev-util/perf/perf-3.12.ebuild
+++ b/dev-util/perf/perf-3.12.ebuild
@@ -17,20 +17,20 @@ if [[ ${PV/_rc} != ${PV} ]] ; then
 	LINUX_VER=$(get_version_component_range 1-2).$(($(get_version_component_range 3)-1))
 	PATCH_VERSION=$(get_version_component_range 1-3)
 	LINUX_PATCH=patch-${PV//_/-}.bz2
-	SRC_URI="mirror://kernel/linux/kernel/v${LINUX_V}/testing/${LINUX_PATCH}
-		mirror://kernel/linux/kernel/v${LINUX_V}/testing/v${PATCH_VERSION}/${LINUX_PATCH}"
+	SRC_URI="https://www.kernel.org/pub/linux/kernel/v${LINUX_V}/testing/${LINUX_PATCH}
+		https://www.kernel.org/pub/linux/kernel/v${LINUX_V}/testing/v${PATCH_VERSION}/${LINUX_PATCH}"
 elif [[ $(get_version_component_count) == 4 ]] ; then
 	# stable-release series
 	LINUX_VER=$(get_version_component_range 1-3)
 	LINUX_PATCH=patch-${PV}.bz2
-	SRC_URI="mirror://kernel/linux/kernel/v${LINUX_V}/${LINUX_PATCH}"
+	SRC_URI="https://www.kernel.org/pub/linux/kernel/v${LINUX_V}/${LINUX_PATCH}"
 else
 	LINUX_VER=${PV}
 	SRC_URI=""
 fi
 
 LINUX_SOURCES="linux-${LINUX_VER}.tar.bz2"
-SRC_URI+=" mirror://kernel/linux/kernel/v${LINUX_V}/${LINUX_SOURCES}"
+SRC_URI+=" https://www.kernel.org/pub/linux/kernel/v${LINUX_V}/${LINUX_SOURCES}"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/dev-util/perf/perf-3.13.1-r1.ebuild
+++ b/dev-util/perf/perf-3.13.1-r1.ebuild
@@ -17,15 +17,15 @@ if [[ ${PV} == *_rc* ]] ; then
 	LINUX_VER=$(get_version_component_range 1-2).$(($(get_version_component_range 3)-1))
 	PATCH_VERSION=$(get_version_component_range 1-3)
 	LINUX_PATCH=patch-${PV//_/-}.xz
-	SRC_URI="mirror://kernel/linux/kernel/v${LINUX_V}/testing/${LINUX_PATCH}
-		mirror://kernel/linux/kernel/v${LINUX_V}/testing/v${PATCH_VERSION}/${LINUX_PATCH}"
+	SRC_URI="https://www.kernel.org/pub/linux/kernel/v${LINUX_V}/testing/${LINUX_PATCH}
+		https://www.kernel.org/pub/linux/kernel/v${LINUX_V}/testing/v${PATCH_VERSION}/${LINUX_PATCH}"
 else
 	VER_COUNT=$(get_version_component_count)
 	if [[ ${VER_COUNT} -gt 2 ]] ; then
 		# stable-release series
 		LINUX_VER=$(get_version_component_range 1-2)
 		LINUX_PATCH=patch-${PV}.xz
-		SRC_URI="mirror://kernel/linux/kernel/v${LINUX_V}/${LINUX_PATCH}"
+		SRC_URI="https://www.kernel.org/pub/linux/kernel/v${LINUX_V}/${LINUX_PATCH}"
 	else
 		LINUX_VER=${PV}
 		SRC_URI=""
@@ -33,7 +33,7 @@ else
 fi
 
 LINUX_SOURCES="linux-${LINUX_VER}.tar.xz"
-SRC_URI+=" mirror://kernel/linux/kernel/v${LINUX_V}/${LINUX_SOURCES}"
+SRC_URI+=" https://www.kernel.org/pub/linux/kernel/v${LINUX_V}/${LINUX_SOURCES}"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/dev-util/perf/perf-3.15.5.ebuild
+++ b/dev-util/perf/perf-3.15.5.ebuild
@@ -17,15 +17,15 @@ if [[ ${PV} == *_rc* ]] ; then
 	LINUX_VER=$(get_version_component_range 1-2).$(($(get_version_component_range 3)-1))
 	PATCH_VERSION=$(get_version_component_range 1-3)
 	LINUX_PATCH=patch-${PV//_/-}.xz
-	SRC_URI="mirror://kernel/linux/kernel/v${LINUX_V}/testing/${LINUX_PATCH}
-		mirror://kernel/linux/kernel/v${LINUX_V}/testing/v${PATCH_VERSION}/${LINUX_PATCH}"
+	SRC_URI="https://www.kernel.org/pub/linux/kernel/v${LINUX_V}/testing/${LINUX_PATCH}
+		https://www.kernel.org/pub/linux/kernel/v${LINUX_V}/testing/v${PATCH_VERSION}/${LINUX_PATCH}"
 else
 	VER_COUNT=$(get_version_component_count)
 	if [[ ${VER_COUNT} -gt 2 ]] ; then
 		# stable-release series
 		LINUX_VER=$(get_version_component_range 1-2)
 		LINUX_PATCH=patch-${PV}.xz
-		SRC_URI="mirror://kernel/linux/kernel/v${LINUX_V}/${LINUX_PATCH}"
+		SRC_URI="https://www.kernel.org/pub/linux/kernel/v${LINUX_V}/${LINUX_PATCH}"
 	else
 		LINUX_VER=${PV}
 		SRC_URI=""
@@ -33,7 +33,7 @@ else
 fi
 
 LINUX_SOURCES="linux-${LINUX_VER}.tar.xz"
-SRC_URI+=" mirror://kernel/linux/kernel/v${LINUX_V}/${LINUX_SOURCES}"
+SRC_URI+=" https://www.kernel.org/pub/linux/kernel/v${LINUX_V}/${LINUX_SOURCES}"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/dev-util/perf/perf-4.1.5-r1.ebuild
+++ b/dev-util/perf/perf-4.1.5-r1.ebuild
@@ -17,15 +17,15 @@ if [[ ${PV} == *_rc* ]] ; then
 	LINUX_VER=$(get_version_component_range 1-2).$(($(get_version_component_range 3)-1))
 	PATCH_VERSION=$(get_version_component_range 1-3)
 	LINUX_PATCH=patch-${PV//_/-}.xz
-	SRC_URI="mirror://kernel/linux/kernel/v${LINUX_V}/testing/${LINUX_PATCH}
-		mirror://kernel/linux/kernel/v${LINUX_V}/testing/v${PATCH_VERSION}/${LINUX_PATCH}"
+	SRC_URI="https://www.kernel.org/pub/linux/kernel/v${LINUX_V}/testing/${LINUX_PATCH}
+		https://www.kernel.org/pub/linux/kernel/v${LINUX_V}/testing/v${PATCH_VERSION}/${LINUX_PATCH}"
 else
 	VER_COUNT=$(get_version_component_count)
 	if [[ ${VER_COUNT} -gt 2 ]] ; then
 		# stable-release series
 		LINUX_VER=$(get_version_component_range 1-2)
 		LINUX_PATCH=patch-${PV}.xz
-		SRC_URI="mirror://kernel/linux/kernel/v${LINUX_V}/${LINUX_PATCH}"
+		SRC_URI="https://www.kernel.org/pub/linux/kernel/v${LINUX_V}/${LINUX_PATCH}"
 	else
 		LINUX_VER=${PV}
 		SRC_URI=""
@@ -33,7 +33,7 @@ else
 fi
 
 LINUX_SOURCES="linux-${LINUX_VER}.tar.xz"
-SRC_URI+=" mirror://kernel/linux/kernel/v${LINUX_V}/${LINUX_SOURCES}"
+SRC_URI+=" https://www.kernel.org/pub/linux/kernel/v${LINUX_V}/${LINUX_SOURCES}"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/dev-util/perf/perf-4.4.4.ebuild
+++ b/dev-util/perf/perf-4.4.4.ebuild
@@ -17,15 +17,15 @@ if [[ ${PV} == *_rc* ]] ; then
 	LINUX_VER=$(get_version_component_range 1-2).$(($(get_version_component_range 3)-1))
 	PATCH_VERSION=$(get_version_component_range 1-3)
 	LINUX_PATCH=patch-${PV//_/-}.xz
-	SRC_URI="mirror://kernel/linux/kernel/v${LINUX_V}/testing/${LINUX_PATCH}
-		mirror://kernel/linux/kernel/v${LINUX_V}/testing/v${PATCH_VERSION}/${LINUX_PATCH}"
+	SRC_URI="https://www.kernel.org/pub/linux/kernel/v${LINUX_V}/testing/${LINUX_PATCH}
+		https://www.kernel.org/pub/linux/kernel/v${LINUX_V}/testing/v${PATCH_VERSION}/${LINUX_PATCH}"
 else
 	VER_COUNT=$(get_version_component_count)
 	if [[ ${VER_COUNT} -gt 2 ]] ; then
 		# stable-release series
 		LINUX_VER=$(get_version_component_range 1-2)
 		LINUX_PATCH=patch-${PV}.xz
-		SRC_URI="mirror://kernel/linux/kernel/v${LINUX_V}/${LINUX_PATCH}"
+		SRC_URI="https://www.kernel.org/pub/linux/kernel/v${LINUX_V}/${LINUX_PATCH}"
 	else
 		LINUX_VER=${PV}
 		SRC_URI=""
@@ -33,7 +33,7 @@ else
 fi
 
 LINUX_SOURCES="linux-${LINUX_VER}.tar.xz"
-SRC_URI+=" mirror://kernel/linux/kernel/v${LINUX_V}/${LINUX_SOURCES}"
+SRC_URI+=" https://www.kernel.org/pub/linux/kernel/v${LINUX_V}/${LINUX_SOURCES}"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/dev-util/perf/perf-4.9.13.ebuild
+++ b/dev-util/perf/perf-4.9.13.ebuild
@@ -17,15 +17,15 @@ if [[ ${PV} == *_rc* ]] ; then
 	LINUX_VER=$(get_version_component_range 1-2).$(($(get_version_component_range 3)-1))
 	PATCH_VERSION=$(get_version_component_range 1-3)
 	LINUX_PATCH=patch-${PV//_/-}.xz
-	SRC_URI="mirror://kernel/linux/kernel/v${LINUX_V}/testing/${LINUX_PATCH}
-		mirror://kernel/linux/kernel/v${LINUX_V}/testing/v${PATCH_VERSION}/${LINUX_PATCH}"
+	SRC_URI="https://www.kernel.org/pub/linux/kernel/v${LINUX_V}/testing/${LINUX_PATCH}
+		https://www.kernel.org/pub/linux/kernel/v${LINUX_V}/testing/v${PATCH_VERSION}/${LINUX_PATCH}"
 else
 	VER_COUNT=$(get_version_component_count)
 	if [[ ${VER_COUNT} -gt 2 ]] ; then
 		# stable-release series
 		LINUX_VER=$(get_version_component_range 1-2)
 		LINUX_PATCH=patch-${PV}.xz
-		SRC_URI="mirror://kernel/linux/kernel/v${LINUX_V}/${LINUX_PATCH}"
+		SRC_URI="https://www.kernel.org/pub/linux/kernel/v${LINUX_V}/${LINUX_PATCH}"
 	else
 		LINUX_VER=${PV}
 		SRC_URI=""
@@ -33,7 +33,7 @@ else
 fi
 
 LINUX_SOURCES="linux-${LINUX_VER}.tar.xz"
-SRC_URI+=" mirror://kernel/linux/kernel/v${LINUX_V}/${LINUX_SOURCES}"
+SRC_URI+=" https://www.kernel.org/pub/linux/kernel/v${LINUX_V}/${LINUX_SOURCES}"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/eclass/kernel-2.eclass
+++ b/eclass/kernel-2.eclass
@@ -373,17 +373,17 @@ detect_version() {
 
 		# at this point 031412, Linus is putting all 3.x kernels in a
 		# 3.x directory, may need to revisit when 4.x is released
-		KERNEL_BASE_URI="mirror://kernel/linux/kernel/v${KV_MAJOR}.x"
+		KERNEL_BASE_URI="https://www.kernel.org/pub/linux/kernel/v${KV_MAJOR}.x"
 
 		[[ -n "${K_LONGTERM}" ]] &&
 			KERNEL_BASE_URI="${KERNEL_BASE_URI}/longterm/v${KV_MAJOR}.${KV_PATCH_ARR}"
 	else
-		#KERNEL_BASE_URI="mirror://kernel/linux/kernel/v${KV_MAJOR}.0"
-		#KERNEL_BASE_URI="mirror://kernel/linux/kernel/v${KV_MAJOR}.${KV_MINOR}"
+		#KERNEL_BASE_URI="https://www.kernel.org/pub/linux/kernel/v${KV_MAJOR}.0"
+		#KERNEL_BASE_URI="https://www.kernel.org/pub/linux/kernel/v${KV_MAJOR}.${KV_MINOR}"
 		if [[ ${KV_MAJOR} -ge 3 ]]; then
-			KERNEL_BASE_URI="mirror://kernel/linux/kernel/v${KV_MAJOR}.x"
+			KERNEL_BASE_URI="https://www.kernel.org/pub/linux/kernel/v${KV_MAJOR}.x"
 		else
-			KERNEL_BASE_URI="mirror://kernel/linux/kernel/v${KV_MAJOR}.${KV_MINOR}"
+			KERNEL_BASE_URI="https://www.kernel.org/pub/linux/kernel/v${KV_MAJOR}.${KV_MINOR}"
 		fi
 
 		[[ -n "${K_LONGTERM}" ]] &&

--- a/eclass/toolchain-binutils.eclass
+++ b/eclass/toolchain-binutils.eclass
@@ -57,7 +57,7 @@ case ${BTYPE} in
 		SRC_URI="ftp://gcc.gnu.org/pub/binutils/snapshots/binutils-${BVER}.tar.bz2
 			ftp://sourceware.org/pub/binutils/snapshots/binutils-${BVER}.tar.bz2" ;;
 	hjlu)
-		SRC_URI="mirror://kernel/linux/devel/binutils/binutils-${BVER}.tar."
+		SRC_URI="https://www.kernel.org/pub/linux/devel/binutils/binutils-${BVER}.tar."
 		version_is_at_least 2.21.51.0.5 && SRC_URI+="xz" || SRC_URI+="bz2" ;;
 	rel) SRC_URI="mirror://gnu/binutils/binutils-${BVER}.tar.bz2" ;;
 esac

--- a/sys-apps/dtc/dtc-1.4.1-r1.ebuild
+++ b/sys-apps/dtc/dtc-1.4.1-r1.ebuild
@@ -8,7 +8,7 @@ if [[ ${PV} == "9999" ]] ; then
 	EGIT_REPO_URI="git://git.kernel.org/pub/scm/utils/dtc/dtc.git"
 	inherit git-2
 else
-	SRC_URI="mirror://kernel/software/utils/${PN}/${P}.tar.xz"
+	SRC_URI="https://www.kernel.org/pub/software/utils/${PN}/${P}.tar.xz"
 	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86"
 fi
 

--- a/sys-apps/dtc/dtc-1.4.1.ebuild
+++ b/sys-apps/dtc/dtc-1.4.1.ebuild
@@ -8,7 +8,7 @@ if [[ ${PV} == "9999" ]] ; then
 	EGIT_REPO_URI="git://git.kernel.org/pub/scm/utils/dtc/dtc.git"
 	inherit git-2
 else
-	SRC_URI="mirror://kernel/software/utils/${PN}/${P}.tar.xz"
+	SRC_URI="https://www.kernel.org/pub/software/utils/${PN}/${P}.tar.xz"
 	KEYWORDS="amd64 arm ~arm64 ppc ppc64 x86"
 fi
 

--- a/sys-apps/dtc/dtc-1.4.2.ebuild
+++ b/sys-apps/dtc/dtc-1.4.2.ebuild
@@ -8,7 +8,7 @@ if [[ ${PV} == "9999" ]] ; then
 	EGIT_REPO_URI="git://git.kernel.org/pub/scm/utils/dtc/dtc.git"
 	inherit git-r3
 else
-	SRC_URI="mirror://kernel/software/utils/${PN}/${P}.tar.xz"
+	SRC_URI="https://www.kernel.org/pub/software/utils/${PN}/${P}.tar.xz"
 	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86"
 fi
 

--- a/sys-apps/dtc/dtc-1.4.3.ebuild
+++ b/sys-apps/dtc/dtc-1.4.3.ebuild
@@ -8,7 +8,7 @@ if [[ ${PV} == "9999" ]] ; then
 	EGIT_REPO_URI="git://git.kernel.org/pub/scm/utils/dtc/dtc.git"
 	inherit git-r3
 else
-	SRC_URI="mirror://kernel/software/utils/${PN}/${P}.tar.xz"
+	SRC_URI="https://www.kernel.org/pub/software/utils/${PN}/${P}.tar.xz"
 	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86"
 fi
 

--- a/sys-apps/dtc/dtc-1.4.4-r1.ebuild
+++ b/sys-apps/dtc/dtc-1.4.4-r1.ebuild
@@ -8,7 +8,7 @@ if [[ ${PV} == "9999" ]] ; then
 	EGIT_REPO_URI="git://git.kernel.org/pub/scm/utils/dtc/dtc.git"
 	inherit git-r3
 else
-	SRC_URI="mirror://kernel/software/utils/${PN}/${P}.tar.xz"
+	SRC_URI="https://www.kernel.org/pub/software/utils/${PN}/${P}.tar.xz"
 	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86"
 fi
 

--- a/sys-apps/dtc/dtc-1.4.4.ebuild
+++ b/sys-apps/dtc/dtc-1.4.4.ebuild
@@ -8,7 +8,7 @@ if [[ ${PV} == "9999" ]] ; then
 	EGIT_REPO_URI="git://git.kernel.org/pub/scm/utils/dtc/dtc.git"
 	inherit git-r3
 else
-	SRC_URI="mirror://kernel/software/utils/${PN}/${P}.tar.xz"
+	SRC_URI="https://www.kernel.org/pub/software/utils/${PN}/${P}.tar.xz"
 	KEYWORDS="~alpha amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc x86"
 fi
 

--- a/sys-apps/dtc/dtc-1.4.6.ebuild
+++ b/sys-apps/dtc/dtc-1.4.6.ebuild
@@ -8,7 +8,7 @@ if [[ ${PV} == "9999" ]] ; then
 	EGIT_REPO_URI="git://git.kernel.org/pub/scm/utils/dtc/dtc.git"
 	inherit git-r3
 else
-	SRC_URI="mirror://kernel/software/utils/${PN}/${P}.tar.xz"
+	SRC_URI="https://www.kernel.org/pub/software/utils/${PN}/${P}.tar.xz"
 	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86"
 fi
 

--- a/sys-apps/dtc/dtc-1.5.0.ebuild
+++ b/sys-apps/dtc/dtc-1.5.0.ebuild
@@ -8,7 +8,7 @@ if [[ ${PV} == "9999" ]] ; then
 	EGIT_REPO_URI="git://git.kernel.org/pub/scm/utils/dtc/dtc.git"
 	inherit git-r3
 else
-	SRC_URI="mirror://kernel/software/utils/${PN}/${P}.tar.xz"
+	SRC_URI="https://www.kernel.org/pub/software/utils/${PN}/${P}.tar.xz"
 	KEYWORDS="~alpha amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86"
 fi
 

--- a/sys-apps/dtc/dtc-9999.ebuild
+++ b/sys-apps/dtc/dtc-9999.ebuild
@@ -8,7 +8,7 @@ if [[ ${PV} == "9999" ]] ; then
 	EGIT_REPO_URI="git://git.kernel.org/pub/scm/utils/dtc/dtc.git"
 	inherit git-r3
 else
-	SRC_URI="mirror://kernel/software/utils/${PN}/${P}.tar.xz"
+	SRC_URI="https://www.kernel.org/pub/software/utils/${PN}/${P}.tar.xz"
 	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86"
 fi
 

--- a/sys-apps/ethtool/ethtool-3.10.ebuild
+++ b/sys-apps/ethtool/ethtool-3.10.ebuild
@@ -5,7 +5,7 @@ EAPI="4"
 
 DESCRIPTION="Utility for examining and tuning ethernet-based network interfaces"
 HOMEPAGE="https://www.kernel.org/pub/software/network/ethtool/"
-SRC_URI="mirror://kernel/software/network/ethtool/${P}.tar.xz"
+SRC_URI="https://www.kernel.org/pub/software/network/ethtool/${P}.tar.xz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/sys-apps/ethtool/ethtool-3.16.ebuild
+++ b/sys-apps/ethtool/ethtool-3.16.ebuild
@@ -5,7 +5,7 @@ EAPI="4"
 
 DESCRIPTION="Utility for examining and tuning ethernet-based network interfaces"
 HOMEPAGE="https://www.kernel.org/pub/software/network/ethtool/"
-SRC_URI="mirror://kernel/software/network/ethtool/${P}.tar.xz"
+SRC_URI="https://www.kernel.org/pub/software/network/ethtool/${P}.tar.xz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/sys-apps/ethtool/ethtool-3.18.ebuild
+++ b/sys-apps/ethtool/ethtool-3.18.ebuild
@@ -5,7 +5,7 @@ EAPI="5"
 
 DESCRIPTION="Utility for examining and tuning ethernet-based network interfaces"
 HOMEPAGE="https://www.kernel.org/pub/software/network/ethtool/"
-SRC_URI="mirror://kernel/software/network/ethtool/${P}.tar.xz"
+SRC_URI="https://www.kernel.org/pub/software/network/ethtool/${P}.tar.xz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/sys-apps/ethtool/ethtool-3.4.2.ebuild
+++ b/sys-apps/ethtool/ethtool-3.4.2.ebuild
@@ -5,7 +5,7 @@ EAPI="4"
 
 DESCRIPTION="Utility for examining and tuning ethernet-based network interfaces"
 HOMEPAGE="https://www.kernel.org/pub/software/network/ethtool/"
-SRC_URI="mirror://kernel/software/network/ethtool/${P}.tar.bz2"
+SRC_URI="https://www.kernel.org/pub/software/network/ethtool/${P}.tar.bz2"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/sys-apps/ethtool/ethtool-4.0.ebuild
+++ b/sys-apps/ethtool/ethtool-4.0.ebuild
@@ -5,7 +5,7 @@ EAPI="5"
 
 DESCRIPTION="Utility for examining and tuning ethernet-based network interfaces"
 HOMEPAGE="https://www.kernel.org/pub/software/network/ethtool/"
-SRC_URI="mirror://kernel/software/network/ethtool/${P}.tar.xz"
+SRC_URI="https://www.kernel.org/pub/software/network/ethtool/${P}.tar.xz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/sys-apps/ethtool/ethtool-4.10.ebuild
+++ b/sys-apps/ethtool/ethtool-4.10.ebuild
@@ -5,7 +5,7 @@ EAPI="5"
 
 DESCRIPTION="Utility for examining and tuning ethernet-based network interfaces"
 HOMEPAGE="https://www.kernel.org/pub/software/network/ethtool/"
-SRC_URI="mirror://kernel/software/network/ethtool/${P}.tar.xz"
+SRC_URI="https://www.kernel.org/pub/software/network/ethtool/${P}.tar.xz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/sys-apps/ethtool/ethtool-4.11.ebuild
+++ b/sys-apps/ethtool/ethtool-4.11.ebuild
@@ -5,7 +5,7 @@ EAPI="5"
 
 DESCRIPTION="Utility for examining and tuning ethernet-based network interfaces"
 HOMEPAGE="https://www.kernel.org/pub/software/network/ethtool/"
-SRC_URI="mirror://kernel/software/network/ethtool/${P}.tar.xz"
+SRC_URI="https://www.kernel.org/pub/software/network/ethtool/${P}.tar.xz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/sys-apps/ethtool/ethtool-4.5.ebuild
+++ b/sys-apps/ethtool/ethtool-4.5.ebuild
@@ -5,7 +5,7 @@ EAPI="5"
 
 DESCRIPTION="Utility for examining and tuning ethernet-based network interfaces"
 HOMEPAGE="https://www.kernel.org/pub/software/network/ethtool/"
-SRC_URI="mirror://kernel/software/network/ethtool/${P}.tar.xz"
+SRC_URI="https://www.kernel.org/pub/software/network/ethtool/${P}.tar.xz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/sys-apps/ethtool/ethtool-4.8.ebuild
+++ b/sys-apps/ethtool/ethtool-4.8.ebuild
@@ -5,7 +5,7 @@ EAPI="5"
 
 DESCRIPTION="Utility for examining and tuning ethernet-based network interfaces"
 HOMEPAGE="https://www.kernel.org/pub/software/network/ethtool/"
-SRC_URI="mirror://kernel/software/network/ethtool/${P}.tar.xz"
+SRC_URI="https://www.kernel.org/pub/software/network/ethtool/${P}.tar.xz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/sys-apps/iproute2/iproute2-4.10.0.ebuild
+++ b/sys-apps/iproute2/iproute2-4.10.0.ebuild
@@ -9,7 +9,7 @@ if [[ ${PV} == "9999" ]] ; then
 	EGIT_REPO_URI="git://git.kernel.org/pub/scm/linux/kernel/git/shemminger/iproute2.git"
 	inherit git-2
 else
-	SRC_URI="mirror://kernel/linux/utils/net/${PN}/${P}.tar.xz"
+	SRC_URI="https://www.kernel.org/pub/linux/utils/net/${PN}/${P}.tar.xz"
 	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86"
 fi
 

--- a/sys-apps/iproute2/iproute2-4.11.0.ebuild
+++ b/sys-apps/iproute2/iproute2-4.11.0.ebuild
@@ -9,7 +9,7 @@ if [[ ${PV} == "9999" ]] ; then
 	EGIT_REPO_URI="git://git.kernel.org/pub/scm/linux/kernel/git/shemminger/iproute2.git"
 	inherit git-2
 else
-	SRC_URI="mirror://kernel/linux/utils/net/${PN}/${P}.tar.xz"
+	SRC_URI="https://www.kernel.org/pub/linux/utils/net/${PN}/${P}.tar.xz"
 	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86"
 fi
 

--- a/sys-apps/iproute2/iproute2-4.12.0.ebuild
+++ b/sys-apps/iproute2/iproute2-4.12.0.ebuild
@@ -9,7 +9,7 @@ if [[ ${PV} == "9999" ]] ; then
 	EGIT_REPO_URI="git://git.kernel.org/pub/scm/linux/kernel/git/shemminger/iproute2.git"
 	inherit git-2
 else
-	SRC_URI="mirror://kernel/linux/utils/net/${PN}/${P}.tar.xz"
+	SRC_URI="https://www.kernel.org/pub/linux/utils/net/${PN}/${P}.tar.xz"
 	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86"
 fi
 

--- a/sys-apps/iproute2/iproute2-4.13.0.ebuild
+++ b/sys-apps/iproute2/iproute2-4.13.0.ebuild
@@ -9,7 +9,7 @@ if [[ ${PV} == "9999" ]] ; then
 	EGIT_REPO_URI="git://git.kernel.org/pub/scm/linux/kernel/git/shemminger/iproute2.git"
 	inherit git-r3
 else
-	SRC_URI="mirror://kernel/linux/utils/net/${PN}/${P}.tar.xz"
+	SRC_URI="https://www.kernel.org/pub/linux/utils/net/${PN}/${P}.tar.xz"
 	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86"
 fi
 

--- a/sys-apps/iproute2/iproute2-4.4.0.ebuild
+++ b/sys-apps/iproute2/iproute2-4.4.0.ebuild
@@ -9,7 +9,7 @@ if [[ ${PV} == "9999" ]] ; then
 	EGIT_REPO_URI="git://git.kernel.org/pub/scm/linux/kernel/git/shemminger/iproute2.git"
 	inherit git-2
 else
-	SRC_URI="mirror://kernel/linux/utils/net/${PN}/${P}.tar.xz"
+	SRC_URI="https://www.kernel.org/pub/linux/utils/net/${PN}/${P}.tar.xz"
 	KEYWORDS="alpha amd64 arm arm64 hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86"
 fi
 

--- a/sys-apps/iproute2/iproute2-4.5.0.ebuild
+++ b/sys-apps/iproute2/iproute2-4.5.0.ebuild
@@ -9,7 +9,7 @@ if [[ ${PV} == "9999" ]] ; then
 	EGIT_REPO_URI="git://git.kernel.org/pub/scm/linux/kernel/git/shemminger/iproute2.git"
 	inherit git-2
 else
-	SRC_URI="mirror://kernel/linux/utils/net/${PN}/${P}.tar.xz"
+	SRC_URI="https://www.kernel.org/pub/linux/utils/net/${PN}/${P}.tar.xz"
 	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86"
 fi
 

--- a/sys-apps/iproute2/iproute2-4.6.0.ebuild
+++ b/sys-apps/iproute2/iproute2-4.6.0.ebuild
@@ -9,7 +9,7 @@ if [[ ${PV} == "9999" ]] ; then
 	EGIT_REPO_URI="git://git.kernel.org/pub/scm/linux/kernel/git/shemminger/iproute2.git"
 	inherit git-2
 else
-	SRC_URI="mirror://kernel/linux/utils/net/${PN}/${P}.tar.xz"
+	SRC_URI="https://www.kernel.org/pub/linux/utils/net/${PN}/${P}.tar.xz"
 	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86"
 fi
 

--- a/sys-apps/iproute2/iproute2-4.7.0.ebuild
+++ b/sys-apps/iproute2/iproute2-4.7.0.ebuild
@@ -9,7 +9,7 @@ if [[ ${PV} == "9999" ]] ; then
 	EGIT_REPO_URI="git://git.kernel.org/pub/scm/linux/kernel/git/shemminger/iproute2.git"
 	inherit git-2
 else
-	SRC_URI="mirror://kernel/linux/utils/net/${PN}/${P}.tar.xz"
+	SRC_URI="https://www.kernel.org/pub/linux/utils/net/${PN}/${P}.tar.xz"
 	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86"
 fi
 

--- a/sys-apps/iproute2/iproute2-4.8.0.ebuild
+++ b/sys-apps/iproute2/iproute2-4.8.0.ebuild
@@ -9,7 +9,7 @@ if [[ ${PV} == "9999" ]] ; then
 	EGIT_REPO_URI="git://git.kernel.org/pub/scm/linux/kernel/git/shemminger/iproute2.git"
 	inherit git-2
 else
-	SRC_URI="mirror://kernel/linux/utils/net/${PN}/${P}.tar.xz"
+	SRC_URI="https://www.kernel.org/pub/linux/utils/net/${PN}/${P}.tar.xz"
 	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86"
 fi
 

--- a/sys-apps/iproute2/iproute2-4.9.0.ebuild
+++ b/sys-apps/iproute2/iproute2-4.9.0.ebuild
@@ -9,7 +9,7 @@ if [[ ${PV} == "9999" ]] ; then
 	EGIT_REPO_URI="git://git.kernel.org/pub/scm/linux/kernel/git/shemminger/iproute2.git"
 	inherit git-2
 else
-	SRC_URI="mirror://kernel/linux/utils/net/${PN}/${P}.tar.xz"
+	SRC_URI="https://www.kernel.org/pub/linux/utils/net/${PN}/${P}.tar.xz"
 	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86"
 fi
 

--- a/sys-apps/iproute2/iproute2-9999.ebuild
+++ b/sys-apps/iproute2/iproute2-9999.ebuild
@@ -9,7 +9,7 @@ if [[ ${PV} == "9999" ]] ; then
 	EGIT_REPO_URI="git://git.kernel.org/pub/scm/linux/kernel/git/shemminger/iproute2.git"
 	inherit git-r3
 else
-	SRC_URI="mirror://kernel/linux/utils/net/${PN}/${P}.tar.xz"
+	SRC_URI="https://www.kernel.org/pub/linux/utils/net/${PN}/${P}.tar.xz"
 	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86"
 fi
 

--- a/sys-apps/kexec-tools/kexec-tools-2.0.14.ebuild
+++ b/sys-apps/kexec-tools/kexec-tools-2.0.14.ebuild
@@ -8,7 +8,7 @@ if [[ ${PV} == "9999" ]] ; then
 	EGIT_REPO_URI="git://git.kernel.org/pub/scm/utils/kernel/kexec/kexec-tools.git"
 	AUTOTOOLS_AUTORECONF=true
 else
-	SRC_URI="mirror://kernel/linux/utils/kernel/kexec/${P}.tar.xz"
+	SRC_URI="https://www.kernel.org/pub/linux/utils/kernel/kexec/${P}.tar.xz"
 	KEYWORDS="amd64 ~arm64 x86"
 fi
 

--- a/sys-apps/kexec-tools/kexec-tools-2.0.16.ebuild
+++ b/sys-apps/kexec-tools/kexec-tools-2.0.16.ebuild
@@ -8,7 +8,7 @@ if [[ ${PV} == "9999" ]] ; then
 	EGIT_REPO_URI="git://git.kernel.org/pub/scm/utils/kernel/kexec/kexec-tools.git"
 	AUTOTOOLS_AUTORECONF=true
 else
-	SRC_URI="mirror://kernel/linux/utils/kernel/kexec/${P}.tar.xz"
+	SRC_URI="https://www.kernel.org/pub/linux/utils/kernel/kexec/${P}.tar.xz"
 	KEYWORDS="~amd64 ~arm64 ~x86"
 fi
 

--- a/sys-apps/kexec-tools/kexec-tools-2.0.17-r1.ebuild
+++ b/sys-apps/kexec-tools/kexec-tools-2.0.17-r1.ebuild
@@ -7,7 +7,7 @@ if [[ ${PV} == "9999" ]] ; then
 	inherit git-r3 autotools
 	EGIT_REPO_URI="https://git.kernel.org/pub/scm/utils/kernel/kexec/kexec-tools.git"
 else
-	SRC_URI="mirror://kernel/linux/utils/kernel/kexec/${P}.tar.xz"
+	SRC_URI="https://www.kernel.org/pub/linux/utils/kernel/kexec/${P}.tar.xz"
 	KEYWORDS="amd64 ~arm64 x86"
 fi
 

--- a/sys-apps/kexec-tools/kexec-tools-2.0.17.ebuild
+++ b/sys-apps/kexec-tools/kexec-tools-2.0.17.ebuild
@@ -7,7 +7,7 @@ if [[ ${PV} == "9999" ]] ; then
 	inherit git-r3 autotools
 	EGIT_REPO_URI="https://git.kernel.org/pub/scm/utils/kernel/kexec/kexec-tools.git"
 else
-	SRC_URI="mirror://kernel/linux/utils/kernel/kexec/${P}.tar.xz"
+	SRC_URI="https://www.kernel.org/pub/linux/utils/kernel/kexec/${P}.tar.xz"
 	KEYWORDS="~amd64 ~arm64 ~x86"
 fi
 

--- a/sys-apps/kexec-tools/kexec-tools-9999.ebuild
+++ b/sys-apps/kexec-tools/kexec-tools-9999.ebuild
@@ -7,7 +7,7 @@ if [[ ${PV} == "9999" ]] ; then
 	inherit git-r3 autotools
 	EGIT_REPO_URI="https://git.kernel.org/pub/scm/utils/kernel/kexec/kexec-tools.git"
 else
-	SRC_URI="mirror://kernel/linux/utils/kernel/kexec/${P}.tar.xz"
+	SRC_URI="https://www.kernel.org/pub/linux/utils/kernel/kexec/${P}.tar.xz"
 	KEYWORDS="~amd64 ~arm64 ~x86"
 fi
 

--- a/sys-apps/kmod/kmod-24.ebuild
+++ b/sys-apps/kmod/kmod-24.ebuild
@@ -11,7 +11,7 @@ if [[ ${PV} == 9999* ]]; then
 	EGIT_REPO_URI="https://git.kernel.org/pub/scm/utils/kernel/${PN}/${PN}.git"
 	inherit autotools git-r3
 else
-	SRC_URI="mirror://kernel/linux/utils/kernel/kmod/${P}.tar.xz"
+	SRC_URI="https://www.kernel.org/pub/linux/utils/kernel/kmod/${P}.tar.xz"
 	KEYWORDS="alpha amd64 arm arm64 hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86"
 	inherit libtool
 fi

--- a/sys-apps/kmod/kmod-25.ebuild
+++ b/sys-apps/kmod/kmod-25.ebuild
@@ -11,7 +11,7 @@ if [[ ${PV} == 9999* ]]; then
 	EGIT_REPO_URI="https://git.kernel.org/pub/scm/utils/kernel/${PN}/${PN}.git"
 	inherit autotools git-r3
 else
-	SRC_URI="mirror://kernel/linux/utils/kernel/kmod/${P}.tar.xz"
+	SRC_URI="https://www.kernel.org/pub/linux/utils/kernel/kmod/${P}.tar.xz"
 	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86"
 	inherit libtool
 fi

--- a/sys-apps/kmod/kmod-9999.ebuild
+++ b/sys-apps/kmod/kmod-9999.ebuild
@@ -11,7 +11,7 @@ if [[ ${PV} == 9999* ]]; then
 	EGIT_REPO_URI="https://git.kernel.org/pub/scm/utils/kernel/${PN}/${PN}.git"
 	inherit autotools git-r3
 else
-	SRC_URI="mirror://kernel/linux/utils/kernel/kmod/${P}.tar.xz"
+	SRC_URI="https://www.kernel.org/pub/linux/utils/kernel/kmod/${P}.tar.xz"
 	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86"
 	inherit libtool
 fi

--- a/sys-apps/man-pages-posix/man-pages-posix-2003a.ebuild
+++ b/sys-apps/man-pages-posix/man-pages-posix-2003a.ebuild
@@ -9,7 +9,7 @@ inherit eutils
 MY_P="${PN}-${PV:0:4}-${PV:0-1}"
 DESCRIPTION="POSIX man-pages (0p, 1p, 3p)"
 HOMEPAGE="http://www.kernel.org/doc/man-pages/"
-SRC_URI="mirror://kernel/linux/docs/man-pages/${PN}/${MY_P}.tar.bz2"
+SRC_URI="https://www.kernel.org/pub/linux/docs/man-pages/${PN}/${MY_P}.tar.bz2"
 
 LICENSE="man-pages-posix"
 SLOT="0"

--- a/sys-apps/man-pages-posix/man-pages-posix-2013a.ebuild
+++ b/sys-apps/man-pages-posix/man-pages-posix-2013a.ebuild
@@ -9,7 +9,7 @@ inherit eutils
 MY_P="${PN}-${PV:0:4}-${PV:0-1}"
 DESCRIPTION="POSIX man-pages (0p, 1p, 3p)"
 HOMEPAGE="http://www.kernel.org/doc/man-pages/"
-SRC_URI="mirror://kernel/linux/docs/man-pages/${PN}/${MY_P}.tar.xz"
+SRC_URI="https://www.kernel.org/pub/linux/docs/man-pages/${PN}/${MY_P}.tar.xz"
 
 LICENSE="man-pages-posix-2013"
 SLOT="0"

--- a/sys-apps/man-pages/man-pages-4.09.ebuild
+++ b/sys-apps/man-pages/man-pages-4.09.ebuild
@@ -7,8 +7,8 @@ GENTOO_PATCH=2
 
 DESCRIPTION="A somewhat comprehensive collection of Linux man pages"
 HOMEPAGE="https://www.kernel.org/doc/man-pages/"
-SRC_URI="mirror://kernel/linux/docs/man-pages/Archive/${P}.tar.xz
-	mirror://kernel/linux/docs/man-pages/${P}.tar.xz
+SRC_URI="https://www.kernel.org/pub/linux/docs/man-pages/Archive/${P}.tar.xz
+	https://www.kernel.org/pub/linux/docs/man-pages/${P}.tar.xz
 	mirror://gentoo/man-pages-gentoo-${GENTOO_PATCH}.tar.bz2
 	https://dev.gentoo.org/~cardoe/files/man-pages-gentoo-${GENTOO_PATCH}.tar.bz2"
 

--- a/sys-apps/man-pages/man-pages-4.10.ebuild
+++ b/sys-apps/man-pages/man-pages-4.10.ebuild
@@ -7,8 +7,8 @@ GENTOO_PATCH=2
 
 DESCRIPTION="A somewhat comprehensive collection of Linux man pages"
 HOMEPAGE="https://www.kernel.org/doc/man-pages/"
-SRC_URI="mirror://kernel/linux/docs/man-pages/Archive/${P}.tar.xz
-	mirror://kernel/linux/docs/man-pages/${P}.tar.xz
+SRC_URI="https://www.kernel.org/pub/linux/docs/man-pages/Archive/${P}.tar.xz
+	https://www.kernel.org/pub/linux/docs/man-pages/${P}.tar.xz
 	mirror://gentoo/man-pages-gentoo-${GENTOO_PATCH}.tar.bz2
 	https://dev.gentoo.org/~cardoe/files/man-pages-gentoo-${GENTOO_PATCH}.tar.bz2"
 

--- a/sys-apps/usbutils/usbutils-007.ebuild
+++ b/sys-apps/usbutils/usbutils-007.ebuild
@@ -10,7 +10,7 @@ inherit base python-single-r1
 
 DESCRIPTION="USB enumeration utilities"
 HOMEPAGE="http://linux-usb.sourceforge.net/"
-SRC_URI="mirror://kernel/linux/utils/usb/${PN}/${P}.tar.xz"
+SRC_URI="https://www.kernel.org/pub/linux/utils/usb/${PN}/${P}.tar.xz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/sys-apps/usbutils/usbutils-008-r1.ebuild
+++ b/sys-apps/usbutils/usbutils-008-r1.ebuild
@@ -9,7 +9,7 @@ inherit python-single-r1
 
 DESCRIPTION="USB enumeration utilities"
 HOMEPAGE="http://linux-usb.sourceforge.net/"
-SRC_URI="mirror://kernel/linux/utils/usb/${PN}/${P}.tar.xz"
+SRC_URI="https://www.kernel.org/pub/linux/utils/usb/${PN}/${P}.tar.xz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/sys-apps/usbutils/usbutils-008.ebuild
+++ b/sys-apps/usbutils/usbutils-008.ebuild
@@ -9,7 +9,7 @@ inherit python-single-r1
 
 DESCRIPTION="USB enumeration utilities"
 HOMEPAGE="http://linux-usb.sourceforge.net/"
-SRC_URI="mirror://kernel/linux/utils/usb/${PN}/${P}.tar.xz"
+SRC_URI="https://www.kernel.org/pub/linux/utils/usb/${PN}/${P}.tar.xz"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/sys-apps/util-linux/util-linux-2.32-r4.ebuild
+++ b/sys-apps/util-linux/util-linux-2.32-r4.ebuild
@@ -17,7 +17,7 @@ if [[ ${PV} == 9999 ]] ; then
 else
 	[[ "${PV}" = *_rc* ]] || \
 	KEYWORDS="alpha amd64 arm arm64 hppa ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~amd64-fbsd ~amd64-linux ~x86-linux"
-	SRC_URI="mirror://kernel/linux/utils/util-linux/v${PV:0:4}/${MY_P}.tar.xz"
+	SRC_URI="https://www.kernel.org/pub/linux/utils/util-linux/v${PV:0:4}/${MY_P}.tar.xz"
 fi
 
 DESCRIPTION="Various useful Linux utilities"

--- a/sys-apps/util-linux/util-linux-2.33-r1.ebuild
+++ b/sys-apps/util-linux/util-linux-2.33-r1.ebuild
@@ -18,7 +18,7 @@ if [[ ${PV} == 9999 ]] ; then
 else
 	[[ "${PV}" = *_rc* ]] || \
 	KEYWORDS="~alpha amd64 ~arm arm64 hppa ia64 ~m68k ~mips ppc ppc64 ~s390 ~sh sparc x86 ~amd64-fbsd ~amd64-linux ~x86-linux"
-	SRC_URI="mirror://kernel/linux/utils/util-linux/v${PV:0:4}/${MY_P}.tar.xz"
+	SRC_URI="https://www.kernel.org/pub/linux/utils/util-linux/v${PV:0:4}/${MY_P}.tar.xz"
 fi
 
 DESCRIPTION="Various useful Linux utilities"

--- a/sys-apps/util-linux/util-linux-2.33.1.ebuild
+++ b/sys-apps/util-linux/util-linux-2.33.1.ebuild
@@ -18,7 +18,7 @@ if [[ ${PV} == 9999 ]] ; then
 else
 	[[ "${PV}" = *_rc* ]] || \
 	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~amd64-linux ~x86-linux"
-	SRC_URI="mirror://kernel/linux/utils/util-linux/v${PV:0:4}/${MY_P}.tar.xz"
+	SRC_URI="https://www.kernel.org/pub/linux/utils/util-linux/v${PV:0:4}/${MY_P}.tar.xz"
 fi
 
 DESCRIPTION="Various useful Linux utilities"

--- a/sys-apps/util-linux/util-linux-9999.ebuild
+++ b/sys-apps/util-linux/util-linux-9999.ebuild
@@ -18,7 +18,7 @@ if [[ ${PV} == 9999 ]] ; then
 else
 	[[ "${PV}" = *_rc* ]] || \
 	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~s390 ~sh ~sparc ~x86 ~amd64-fbsd ~amd64-linux ~x86-linux"
-	SRC_URI="mirror://kernel/linux/utils/util-linux/v${PV:0:4}/${MY_P}.tar.xz"
+	SRC_URI="https://www.kernel.org/pub/linux/utils/util-linux/v${PV:0:4}/${MY_P}.tar.xz"
 fi
 
 DESCRIPTION="Various useful Linux utilities"

--- a/sys-libs/libcap/libcap-2.24-r2.ebuild
+++ b/sys-libs/libcap/libcap-2.24-r2.ebuild
@@ -8,7 +8,7 @@ inherit eutils multilib multilib-minimal toolchain-funcs pam
 
 DESCRIPTION="POSIX 1003.1e capabilities"
 HOMEPAGE="http://www.friedhoff.org/posixfilecaps.html"
-SRC_URI="mirror://kernel/linux/libs/security/linux-privs/libcap2/${P}.tar.xz"
+SRC_URI="https://www.kernel.org/pub/linux/libs/security/linux-privs/libcap2/${P}.tar.xz"
 
 # it's available under either of the licenses
 LICENSE="|| ( GPL-2 BSD )"

--- a/sys-libs/libcap/libcap-2.25.ebuild
+++ b/sys-libs/libcap/libcap-2.25.ebuild
@@ -8,7 +8,7 @@ inherit eutils multilib multilib-minimal toolchain-funcs pam
 
 DESCRIPTION="POSIX 1003.1e capabilities"
 HOMEPAGE="http://www.friedhoff.org/posixfilecaps.html"
-SRC_URI="mirror://kernel/linux/libs/security/linux-privs/libcap2/${P}.tar.xz"
+SRC_URI="https://www.kernel.org/pub/linux/libs/security/linux-privs/libcap2/${P}.tar.xz"
 
 # it's available under either of the licenses
 LICENSE="|| ( GPL-2 BSD )"


### PR DESCRIPTION
The kernel mirror was dropped from the thirdpartymirrors file in
profiles, so it's use needs to be replaced with an address to
kernel.org.

It's a quick hack to fix the issue without spending too much time on updating every single package. The change in SRC_URIs were done with `sed -i'' -e 's!mirror://kernel!https://www.kernel.org/pub!g' $(git grep 'mirror://kernel' | cut -f1 -d: | grep -e '\.\(eclass\|ebuild\)$' | sort -u)`.

Needs to be merged together with https://github.com/kinvolk/coreos-overlay/pull/851.

Test build: http://localhost:9091/job/os/job/manifest/2062/