### PR TITLE
SDK bootstrap related fixes in scripts/bootstrap: use python3; add static-libs, openmp

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -168,8 +168,8 @@ cleanup() {
 }
 
 pycmd() {
-	[[ ${DEBUG} = "1" ]] && echo /usr/bin/python -c "$@" > /dev/stderr
-	/usr/bin/python -c "$@"
+	[[ ${DEBUG} = "1" ]] && echo /usr/bin/python3 -c "$@" > /dev/stderr
+	/usr/bin/python3 -c "$@"
 }
 
 # TSTP messes ^Z of bootstrap up, so we don't trap it anymore.
@@ -319,7 +319,7 @@ if [ ${BOOTSTRAP_STAGE} -le 1 ] ; then
 	echo -------------------------------------------------------------------------------
 	set_bootstrap_stage 2
 fi
-export USE="-* bootstrap ${ALLOWED_USE} ${BOOTSTRAP_USE}"
+export USE="-* bootstrap ${ALLOWED_USE} ${BOOTSTRAP_USE} openmp static-libs"
 
 # We can't unmerge headers which may or may not exist yet. If your
 # trying to use nptl, it may be needed to flush out any old headers


### PR DESCRIPTION
# SDK bootstrap related fixes

This change explicitly calls python3 (instead of python) in pycmd
so portage commands work (as we ship python 2, too, and it's still
the default).

Also, `static-libs` and `openmp` are added to the
bootstrap emerge USE flags (stage 3 of the bootstrap-sh script,
which is run in stage 2 of the SDK catalyst bootstrapping process):
- `static-libs` un-breaks the zlib build: zlib installed has this flag
   set and zlib requested per emerge command line in
   bootstrap.sh stage 3 needs this flag to prevent a slot conflict.
- `openmp` is to honour requirements of newer versions of GCC and is
   added according to Gentoo guidelines published here:
   https://wiki.gentoo.org/wiki/User:Sakaki/Sakaki%27s_EFI_Install_Guide/Building_the_Gentoo_Base_System_Minus_Kernel#Gentoo_Bootstrap_Remix:_Progressing_from_Stage_1_to_Stage_2

# How to use

Needed in combination with
* coreos-overlay: https://github.com/kinvolk/coreos-overlay/pull/874
* flatcar-scripts: https://github.com/kinvolk/flatcar-scripts/pull/123 (the main PR)

```
$ cork enter
$ sudo ./bootstrap_sdk
```

# Testing done

SDK CI build (manifest #2158) passed.