### PR TITLE
sys-apps/gentoo-functions: use tarball from github

### DIFF
--- a/sys-apps/gentoo-functions/gentoo-functions-0.13.ebuild
+++ b/sys-apps/gentoo-functions/gentoo-functions-0.13.ebuild
@@ -7,7 +7,7 @@ if [[ ${PV} == 9999* ]]; then
 	inherit git-r3
 	EGIT_REPO_URI="https://anongit.gentoo.org/git/proj/gentoo-functions.git"
 else
-	SRC_URI="https://gitweb.gentoo.org/proj/gentoo-functions.git/snapshot/${P}.tar.gz"
+	SRC_URI="https://github.com/gentoo/gentoo-functions/archive/refs/tags/${PV}.tar.gz -> ${P}.tar.gz"
 	KEYWORDS="~alpha amd64 arm arm64 hppa ~ia64 ~m68k ~mips ppc ppc64 ~riscv s390 sparc x86 ~ppc-aix ~x64-cygwin ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~x86-macos ~m68k-mint ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris ~x86-winnt"
 fi
 


### PR DESCRIPTION
This one-line change pulls the gentoo-functions source tarball from
github instead from gentoo's own gitweb, to stabilise the build process.
We assume github to have higher availability than gentoo gitweb.

Signed-off-by: Thilo Fromm <thilo@kinvolk.io>