### PR TITLE
Revert "Unmasks for arm64 required by glibc-2.33 upgrade"

### DIFF
--- a/app-misc/pax-utils/pax-utils-1.1.6.ebuild
+++ b/app-misc/pax-utils/pax-utils-1.1.6.ebuild
@@ -14,7 +14,7 @@ SRC_URI="mirror://gentoo/${P}.tar.xz
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="alpha amd64 arm arm64 hppa ~ia64 ~m68k ~mips ppc ppc64 ~s390 ~sh ~sparc x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd"
+KEYWORDS="alpha amd64 arm ~arm64 hppa ~ia64 ~m68k ~mips ppc ppc64 ~s390 ~sh ~sparc x86 ~amd64-fbsd ~sparc-fbsd ~x86-fbsd"
 IUSE="caps debug python seccomp"
 
 RDEPEND="caps? ( >=sys-libs/libcap-2.24 )

--- a/dev-libs/libev/libev-4.15-r1.ebuild
+++ b/dev-libs/libev/libev-4.15-r1.ebuild
@@ -13,7 +13,7 @@ SRC_URI="http://dist.schmorp.de/libev/${P}.tar.gz
 
 LICENSE="|| ( BSD GPL-2 )"
 SLOT="0"
-KEYWORDS="~alpha amd64 ~arm arm64 ~hppa ~ia64 ~m68k ~mips ppc ~ppc64 ~s390 ~sh ~sparc x86 ~amd64-fbsd ~x86-fbsd ~x86-freebsd ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos"
+KEYWORDS="~alpha amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ppc ~ppc64 ~s390 ~sh ~sparc x86 ~amd64-fbsd ~x86-fbsd ~x86-freebsd ~amd64-linux ~x86-linux ~ppc-macos ~x86-macos"
 IUSE="elibc_glibc static-libs"
 
 # Bug #283558

--- a/dev-libs/libverto/libverto-0.2.5-r1.ebuild
+++ b/dev-libs/libverto/libverto-0.2.5-r1.ebuild
@@ -12,7 +12,7 @@ SRC_URI="https://fedorahosted.org/releases/l/i/libverto/${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="~alpha amd64 ~arm arm64 ~hppa ~ia64 ~m68k ~mips ppc ~ppc64 ~s390 ~sh ~sparc x86 ~amd64-fbsd"
+KEYWORDS="~alpha amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ppc ~ppc64 ~s390 ~sh ~sparc x86 ~amd64-fbsd"
 IUSE="glib +libev libevent tevent +threads static-libs"
 
 # file collisions

--- a/virtual/acl/acl-0-r1.ebuild
+++ b/virtual/acl/acl-0-r1.ebuild
@@ -10,7 +10,7 @@ SRC_URI=""
 
 LICENSE=""
 SLOT="0"
-KEYWORDS="alpha amd64 arm64 arm ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~ia64-linux ~x86-linux"
+KEYWORDS="alpha amd64 arm ia64 m68k ~mips ppc ppc64 s390 sh sparc x86 ~amd64-fbsd ~x86-fbsd ~amd64-linux ~ia64-linux ~x86-linux"
 IUSE="static-libs"
 
 DEPEND=""


### PR DESCRIPTION
Related with https://github.com/kinvolk/coreos-overlay/pull/1080

Reverts kinvolk/portage-stable#177